### PR TITLE
Remove timeout that causes MemoryWatcher to crash p3

### DIFF
--- a/p3/memory_watcher.py
+++ b/p3/memory_watcher.py
@@ -16,7 +16,6 @@ class MemoryWatcher:
         except OSError:
             pass
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-        self.sock.settimeout(0.001)
         self.sock.bind(path)
 
     def __iter__(self):

--- a/p3/memory_watcher_test.py
+++ b/p3/memory_watcher_test.py
@@ -8,6 +8,7 @@ class MemoryWatcherTest(unittest.TestCase):
     def setUp(self):
         self.sock_path = os.getcwd() + '/sock'
         self.mw = MemoryWatcher(self.sock_path)
+        self.mw.sock.settimeout(1)
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
 
     def test_memory_watcher_recv(self):
@@ -26,6 +27,7 @@ class MemoryWatcherTest(unittest.TestCase):
             ]
 
         for actual, expected in zip(self.mw, expecteds):
+            # print(actual)
             self.assertEqual(actual, expected)
 
     def test_memory_watcher_timeout(self):


### PR DESCRIPTION
Even when running p3 while emulation is active, this timeout procs immediately.

It's pretty nice to be able to start p3 related scripts before starting emulation anyway to ensure you get all of the addresses.
