### PR TITLE
State callbacks

### DIFF
--- a/p3/state_manager.py
+++ b/p3/state_manager.py
@@ -23,7 +23,10 @@ def int_handler(obj, name, shift=0, mask=0xFFFFFFFF, wrapper=None, default=0):
         transformed = (struct.unpack('>i', value)[0] >> shift) & mask
         wrapped = transformed if wrapper is None else wrapper(transformed)
         setattr(obj, name, wrapped)
+        for cb in getattr(obj, name + "_changed"):
+            cb(obj)
     setattr(obj, name, default)
+    setattr(obj, name + "_changed", [])
     return handle
 
 def float_handler(obj, name, wrapper=None, default=0.0):
@@ -34,7 +37,10 @@ def float_handler(obj, name, wrapper=None, default=0.0):
     def handle(value):
         as_float = struct.unpack('>f', value)[0]
         setattr(obj, name, as_float if wrapper is None else wrapper(as_float))
+        for cb in getattr(obj, name + "_changed"):
+            cb(obj)
     setattr(obj, name, default)
+    setattr(obj, name + "_changed", [])
     return handle
 
 def add_address(x, y):

--- a/p3/state_manager.py
+++ b/p3/state_manager.py
@@ -7,42 +7,6 @@ from p3.state import Menu
 from p3.state import Stage
 from p3.state import ActionState
 
-def int_handler(obj, name, shift=0, mask=0xFFFFFFFF, wrapper=None, default=0):
-    """Returns a handler that sets an attribute for a given object.
-
-    obj is the object that will have its attribute set. Probably a State.
-    name is the attribute name to be set.
-    shift will be applied before mask.
-    Finally, wrapper will be called on the value if it is not None.
-
-    This sets the attribute to default when called. Note that the actual final
-    value doesn't need to be an int. The wrapper can convert int to whatever.
-    This is particularly useful for enums.
-    """
-    def handle(value):
-        transformed = (struct.unpack('>i', value)[0] >> shift) & mask
-        wrapped = transformed if wrapper is None else wrapper(transformed)
-        setattr(obj, name, wrapped)
-        for cb in getattr(obj, name + "_changed"):
-            cb(obj)
-    setattr(obj, name, default)
-    setattr(obj, name + "_changed", [])
-    return handle
-
-def float_handler(obj, name, wrapper=None, default=0.0):
-    """Returns a handler that sets an attribute for a given object.
-
-    Similar to int_handler, but no mask or shift.
-    """
-    def handle(value):
-        as_float = struct.unpack('>f', value)[0]
-        setattr(obj, name, as_float if wrapper is None else wrapper(as_float))
-        for cb in getattr(obj, name + "_changed"):
-            cb(obj)
-    setattr(obj, name, default)
-    setattr(obj, name + "_changed", [])
-    return handle
-
 def add_address(x, y):
     """Returns a string representation of the sum of the two parameters.
 
@@ -58,9 +22,9 @@ class StateManager:
         self.state = state
         self.addresses = {}
 
-        self.addresses['80479D60'] = int_handler(self.state, 'frame')
-        self.addresses['80479D30'] = int_handler(self.state, 'menu', 0, 0xFF, Menu, Menu.Characters)
-        self.addresses['804D6CAC'] = int_handler(self.state, 'stage', 8, 0xFF, Stage, Stage.Unselected)
+        self.addresses['80479D60'] = self.int_handler(self.state, 'frame')
+        self.addresses['80479D30'] = self.int_handler(self.state, 'menu', 0, 0xFF, Menu, Menu.Characters)
+        self.addresses['804D6CAC'] = self.int_handler(self.state, 'stage', 8, 0xFF, Stage, Stage.Unselected)
 
         self.state.players = []
         for player_id in range(4):
@@ -69,16 +33,16 @@ class StateManager:
             data_pointer = add_address('80453130', 0xE90 * player_id)
 
             type_address = add_address('803F0E08', 0x24 * player_id)
-            type_handler = int_handler(player, 'type', 24, 0xFF, PlayerType, PlayerType.Unselected)
-            character_handler = int_handler(player, 'character', 8, 0xFF, Character, Character.Unselected)
+            type_handler = self.int_handler(player, 'type', 24, 0xFF, PlayerType, PlayerType.Unselected)
+            character_handler = self.int_handler(player, 'character', 8, 0xFF, Character, Character.Unselected)
             self.addresses[type_address] = [type_handler, character_handler]
 
             state_address = data_pointer + ' 70'
-            state_handler = int_handler(player, 'action_state', 0, 0xFFFF, ActionState, ActionState.Unselected)
+            state_handler = self.int_handler(player, 'action_state', 0, 0xFFFF, ActionState, ActionState.Unselected)
             self.addresses[state_address] = state_handler
 
             ground_address = data_pointer + ' 140'
-            ground_handler = int_handler(player, 'on_ground', 0, 0xFFFF, lambda x: x == 0, True)
+            ground_handler = self.int_handler(player, 'on_ground', 0, 0xFFFF, lambda x: x == 0, True)
             self.addresses[ground_address] = ground_handler
 
     def handle(self, address, value):
@@ -94,3 +58,40 @@ class StateManager:
     def locations(self):
         """Returns a list of addresses for exporting to Locations.txt."""
         return self.addresses.keys()
+
+
+    def int_handler(self, obj, name, shift=0, mask=0xFFFFFFFF, wrapper=None, default=0):
+        """Returns a handler that sets an attribute for a given object.
+
+        obj is the object that will have its attribute set. Probably a State.
+        name is the attribute name to be set.
+        shift will be applied before mask.
+        Finally, wrapper will be called on the value if it is not None.
+
+        This sets the attribute to default when called. Note that the actual final
+        value doesn't need to be an int. The wrapper can convert int to whatever.
+        This is particularly useful for enums.
+        """
+        def handle(value):
+            transformed = (struct.unpack('>i', value)[0] >> shift) & mask
+            wrapped = transformed if wrapper is None else wrapper(transformed)
+            setattr(obj, name, wrapped)
+            for cb in getattr(obj, name + "_changed"):
+                cb(self.state)
+        setattr(obj, name, default)
+        setattr(obj, name + "_changed", [])
+        return handle
+
+    def float_handler(self, obj, name, wrapper=None, default=0.0):
+        """Returns a handler that sets an attribute for a given object.
+
+        Similar to int_handler, but no mask or shift.
+        """
+        def handle(value):
+            as_float = struct.unpack('>f', value)[0]
+            setattr(obj, name, as_float if wrapper is None else wrapper(as_float))
+            for cb in getattr(obj, name + "_changed"):
+                cb(self.state)
+        setattr(obj, name, default)
+        setattr(obj, name + "_changed", [])
+        return handle

--- a/p3/state_manager.py
+++ b/p3/state_manager.py
@@ -59,7 +59,6 @@ class StateManager:
         """Returns a list of addresses for exporting to Locations.txt."""
         return self.addresses.keys()
 
-
     def int_handler(self, obj, name, shift=0, mask=0xFFFFFFFF, wrapper=None, default=0):
         """Returns a handler that sets an attribute for a given object.
 
@@ -74,7 +73,12 @@ class StateManager:
         """
         def handle(value):
             transformed = (struct.unpack('>i', value)[0] >> shift) & mask
-            wrapped = transformed if wrapper is None else wrapper(transformed)
+            wrapped = transformed
+            if wrapper is not None:
+                try:
+                    wrapped = wrapper(transformed)
+                except ValueError:
+                    wrapped = default
             setattr(obj, name, wrapped)
             for cb in getattr(obj, name + "_changed"):
                 cb(self.state)
@@ -89,7 +93,12 @@ class StateManager:
         """
         def handle(value):
             as_float = struct.unpack('>f', value)[0]
-            setattr(obj, name, as_float if wrapper is None else wrapper(as_float))
+            if wrapper is not None:
+                try:
+                    as_float = wrapper(as_float)
+                except ValueError:
+                    as_float = default
+            setattr(obj, name, as_float)
             for cb in getattr(obj, name + "_changed"):
                 cb(self.state)
         setattr(obj, name, default)


### PR DESCRIPTION
Really simple implementation, but effective.

``` python
state.players[0].action_state_changed.append(lambda x: print(x.players[0].action_state))
state.frame_changed.append(lambda x: print(x.frame))
```

To get the dispatchers to pass in the state object rather than the player object in the first line above, I put the handler functions into `StateManager`. This is a pretty good solution, but there might be a better one. Otherwise, if this looks good I'll write the tests. 
